### PR TITLE
Generate CV PDF during site build

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -30,20 +30,13 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.162.1
     steps:
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ env.HUGO_VERSION }}
-          extended: true
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v6
@@ -53,9 +46,11 @@ jobs:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
         run: |
-          hugo \
+          nix develop --command hugo \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Build CV PDF
+        run: nix develop --command just cv-pdf
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,25 +11,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      HUGO_VERSION: 0.162.1
     steps:
-      - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
-        with:
-          hugo-version: ${{ env.HUGO_VERSION }}
-          extended: true
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
       - name: Checkout
         uses: actions/checkout@v6
         with:
           submodules: recursive
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
       - name: Build with Hugo
         env:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
-        run: hugo --minify
+        run: nix develop --command just build
 
   lint:
     runs-on: ubuntu-latest

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -388,6 +388,7 @@ Codabox
 Codabox's
 codebase
 Coolen
+DAgafschrift
 COPD
 Decramer
 deployable
@@ -398,6 +399,7 @@ Exadaktylos
 FastAPI
 Fontana
 GitLab
+geCOdeerd
 Guarino
 hausmaus
 Hemeryck
@@ -438,6 +440,7 @@ serverless
 SFTP
 Slagmolen
 SoundTalks
+sourcery
 Stievie
 stievie
 Tele

--- a/content/about.md
+++ b/content/about.md
@@ -38,7 +38,7 @@ The writing is mostly practical: documenting decisions, implementation details, 
 
 ## Links
 
-- Full CV: [Martijn Hemeryck CV](/cv/)
+- Full CV: [web](/cv/) and [PDF](/cv/martijn-hemeryck-cv.pdf)
 - GitHub: [mhemeryck](https://github.com/mhemeryck)
 - LinkedIn: [martijn-hemeryck](https://linkedin.com/in/martijn-hemeryck-67896245)
 - Blog: [Martyn's musings](/posts/)

--- a/content/cv.md
+++ b/content/cv.md
@@ -168,8 +168,8 @@ Selected projects and responsibilities:
 
 - Dries Berckmans, Martijn Hemeryck, Daniel Berckmans, Erik Vranken, and Toon van Waterschoot: "Animal Sound...Talks! Real-time Sound Analysis for Health Monitoring in Livestock", Animal Environment and Welfare, 2015.
 - Ilaria Fontana, Emanuela Tullo, Martijn Hemeryck, and Marcella Guarino: "Using Broiler Sound Frequency to Model Weight", Animal Environment and Welfare, 2015.
-- Martijn Hemeryck, Dries Berckmans, Erik Vranken, Emanuela Tullo, Ilaria Fontana, Marcella Guarino, and Toon van Waterschoot: ["The Pig Cough Monitor in the EU-PLF project: results and multimodal data analysis"](http://www.eu-plf.eu/index.php/events/event/ec-plf-2015/), Precision Livestock Farming '15, 2015.
-- Martijn Hemeryck and Dries Berckmans: ["Pig cough monitoring in the EU-PLF project: first results"](http://old.eaap.org/Previous_Annual_Meetings/2014Copenhagen/Papers/Published/S11_04.pdf), Precision livestock farming applications, 2014.
+- Martijn Hemeryck, Dries Berckmans, Erik Vranken, Emanuela Tullo, Ilaria Fontana, Marcella Guarino, and Toon van Waterschoot: "The Pig Cough Monitor in the EU-PLF project: results and multimodal data analysis", Precision Livestock Farming '15, 2015.
+- Martijn Hemeryck and Dries Berckmans: "Pig cough monitoring in the EU-PLF project: first results", Precision livestock farming applications, 2014.
 - Marko Topalovic, Vasileios Exadaktylos, Anneleen Peeters, Johan Coolen, Walter Dewever, Martijn Hemeryck, Pieter Slagmolen, Karl Janssens, Daniel Berckmans, Marc Decramer, and Wim Janssens: ["Computer quantification of airway collapse on forced expiration to predict the presence of emphysema"](http://dx.doi.org/10.1186/1465-9921-14-131), Respiratory Research, 2013.
 
 ### Presentations And Posters

--- a/content/cv.md
+++ b/content/cv.md
@@ -3,23 +3,17 @@ title = "CV"
 subtitle = "Martijn Hemeryck"
 +++
 
-## Contact
-
-- Location: [Tongeren-Borgloon, Belgium](geo:50.7865,5.4174)
-- GitHub: [mhemeryck](https://github.com/mhemeryck)
-- LinkedIn: [martijn-hemeryck](https://linkedin.com/in/martijn-hemeryck-67896245)
-- Stack Overflow: [martyn](https://stackoverflow.com/users/1393391/martyn)
-- Blog: [Martyn's musings](https://mhemeryck.github.io/posts/)
-
 ## Profile
 
-Engineer with an electrical engineering background, originally specialized in embedded software and digital signal processing.
+I'm Martijn, a software developer with an electrical engineering background.
 
-Over time I branched into broader backend, cloud, infrastructure, and full-stack engineering.
+During my studies, I specialized in embedded software and digital signal processing.
+
+Over time I branched into broader backend, cloud, infrastructure, and full-stack software development.
 I focus on product-facing platforms where technical design, operational reliability, and domain understanding all matter.
 
 I like to analyze systems, take them apart, design them, and build them up again.
-I am a developer and maker at heart, with a practical drive to solve problems end to end.
+I am a developer and maker at heart, with a practical drive to solve problems end-to-end.
 
 ## Experience
 
@@ -28,67 +22,77 @@ I am a developer and maker at heart, with a practical drive to solve problems en
 **Senior Software Engineer**
 August 2018 - present
 
-Codabox provides accounting-data feeds for accountants and bookkeepers.
+Codabox provides accounting data for accountants and bookkeepers.
 The platform integrates with source providers such as banks, payroll offices, credit card providers, and e-invoicing solutions.[^peppol]
 It handles both sourcing and delivery of accounting data, as well as the consent flows required to make those end-to-end data exchanges possible.
 My work has moved across backend and frontend development, analysis, architecture, cloud infrastructure, and technical leadership on several of these systems.
 
 Selected projects and achievements:
 
-#### 2025-2026: Sourcery And CODA Domain Tooling
+#### 2025-2026: Sourcery And CODA Domain Tooling[^coda]
 
-- Worked on a new solution for generating historical bank statements from open-banking data.[^open-banking]
-- Helped steer the team toward a Go-first implementation model for new services.
-- Built the monorepo foundation for multiple services, combining application code, infrastructure code, and CI pipelines in a single versioned context.
-- Designed and built the serverless-first infrastructure foundation, using AWS Lambda as the main runtime platform for new services.
-- Developed optimized CODA bank-statement parsing and generation code with minimal allocations and memory usage.
+Accountants need a full overview of their clients' bank statements data, even if the banks cannot provide it directly.
+
+- Helped build services that generate historical bank statements from open-banking data.[^open-banking]
+- Steer the (sourcery) team toward a Go-first implementation model.
+- Built the monorepo foundation for application code, infrastructure code and CI pipelines.
+- Designed a serverless-first AWS Lambda infrastructure foundation.
+- Developed low-allocation CODA bank-statement parsing and generation code.
 - Introduced LLM-assisted tooling and project context to make team workflows easier to navigate.
 
 #### 2023-2025: Partner SFTP And Bank Connectivity
 
-- Onboarded and stabilized file exchange with banks, social offices, and external partners.
-- Worked directly on network-level integrations using SFTP, VPNs, allowlisted IPs, credentials, and partner-specific validation.
-- Set up connectivity and supporting infrastructure with infrastructure-as-code according to security requirements and operational best practices.
-- Helped prevent silent data loss, failed transfers, and manual troubleshooting.
+Our team needed to take direct responsibility for VPN-based banking and payroll connectivity, where reliable file exchange depends on both network setup and partner-specific validation.
+
+- Onboarded and stabilized SFTP-based file exchange with banks, payroll offices, and external partners.
+- Worked through network-level integration details such as VPNs, allowlisted IPs, credentials, partner validation, and operational handover.
+- Provisioned connectivity and supporting infrastructure with infrastructure-as-code according to security and operational requirements.
+- Reduced the risk of silent data loss, failed transfers, and manual troubleshooting in partner integrations.
 
 #### 2023: CARO / Credit Card Statement Activation Flows
 
-- CARO is Codabox's credit card statement offering to accountants.
-- Our team inherited an initial Java implementation and wanted to migrate it toward a Go-based stack.
-- At the same time, there was a business requirement to onboard an additional source provider.
-- Helped set up an approach to migrate the implementation endpoint-by-endpoint from Java to Go while keeping both systems operational in production.
-- Helped fulfill the extra source provider requirement during the migration instead of treating modernization and delivery as separate tracks.
+Codabox needed to onboard a new credit-card statement source provider while the team was moving new development toward a Go-first implementation model.
+
+- Helped migrate the implementation endpoint by endpoint from Java to Go while keeping both systems operational in production.
+- Supported the new source-provider onboarding as part of the migration path.
+- Helped combine business delivery and modernization instead of treating them as separate tracks.
 
 #### 2021-2022: Consent And Mandate Signing Platform
 
-- Clients of accountants need to consent that banks can share their data with Codabox and that Codabox can share that data with their accountant.
-- Helped replace a largely paper-based mandate process with a digital signing flow during the onboarding of a new bank.
-- Integrated a third-party digital signing provider with the existing Codabox systems to support a fully digital process for both mandates.
-- Built the solution as a reusable production flow that most integrated banks later adopted, and that remains in use for digital mandate signing.
+Codabox needed a digital mandate signing flow while onboarding a new source bank, replacing a process that still depended largely on paper mandates.
+
+- Helped design and implement the consent and mandate signing flow for clients of accountants.
+- Integrated a third-party digital signing provider with existing Codabox systems.
+- Supported fully digital processing for both sharing mandates.
+- The resulting production flow was later adopted by most integrated banks and remains in use.
 
 #### 2018-2020: Faster CODA Processing
 
-- The core Codabox system had issues delivering sourced CODA files from banks to customers on time.
-- Reworked the intermediate batch-processing steps so file processing could run in parallel.
-- Increased overall throughput and helped ensure customers received their files before 8h00 in the morning.
+Codabox needed to deliver bank-sourced CODA files[^coda] to customers before the start of the working day, but intermediate batch processing limited throughput.
+
+- Reworked batch-processing steps so file processing could run in parallel.
+- Increased throughput and helped ensure customers received their files before 8h00.
 
 #### Ongoing: MyCodabox And Support Visibility
 
-- Worked beyond backend and infrastructure on customer-facing portals and internal support tooling.
+Codabox needed customer-facing and support-facing tools that made activation, mandate, subscription, and delivery states visible across operational workflows.
+
 - Contributed to [MyCodabox](https://www.mycodabox.com/), the main portal accountants use to manage mandates and subscriptions.
-- Worked on MyConsent, an onboarding tool for accountants' clients to safely activate integrations such as credit card statements according to [PCI](https://www.pcisecuritystandards.org/standards/pci-dss/) guidelines.
+- Worked on MyConsent, an onboarding tool for accountants' clients to activate integrations such as credit card statements according to [PCI](https://www.pcisecuritystandards.org/standards/pci-dss/) guidelines.
 - Did the groundwork for an [Electron](https://www.electronjs.org/)-based desktop delivery client where local customer workflows required a dedicated application.
 - Built and improved internal support tooling, including Django-admin-based and React-based interfaces.
-- Added visibility for activation, registration, reconnect, CARO, reporting, and failure states across customer-facing and support-facing flows.
+- Added visibility for activation, registration, reconnect, reporting, and failure states across customer-facing and support-facing flows.
 
 #### Ongoing: Cloud, CI, And Security Modernization
 
-- Work in a DevOps model where the team runs and manages its own infrastructure.
-- Manage infrastructure through infrastructure-as-code, mostly with Terraform.
+The team needed cloud infrastructure, CI, and security practices that kept services deployable and auditable while the platform evolved across GCP and AWS.
+
+- Worked in a DevOps model where the team runs and manages its own infrastructure.
+- Managed infrastructure through infrastructure-as-code, mostly with Terraform.
 - Worked mostly on GCP-based systems before leading the team's transition toward AWS.
-- Bring hands-on experience selecting appropriate cloud technologies, from VMs and Kubernetes deployments to serverless runtimes such as GCP Cloud Run and AWS Lambda.
-- Manage and improve CI pipelines across CircleCI, GitHub Actions, and GitLab CI.
-- Keep production services always deployable, auditable, and aligned with security expectations.
+- Selected appropriate cloud technologies, from VMs and Kubernetes deployments to serverless runtimes such as GCP Cloud Run and AWS Lambda.
+- Managed and improved CI pipelines across CircleCI, GitHub Actions, and GitLab CI.
+- Kept production services deployable, auditable, and aligned with security expectations.
 
 ### [Unleashed](https://unleashed.be) / [Mobile Vikings](https://mobilevikings.be)
 
@@ -102,14 +106,18 @@ Selected projects and responsibilities:
 
 #### 2017-2018: Marketing Automation Squad
 
-- Worked on cross-brand full-stack development for Mobile Vikings, Jim Mobile, and Stievie.
+Mobile Vikings, Jim Mobile, and Stievie needed shared marketing automation capabilities across customer-facing telecom and media products.
+
+- Worked on cross-brand full-stack development across the three brands.
 - Helped analyze and shape backend REST API architecture for marketing automation flows.
 
 #### 2016-2017: Mobile Vikings Get And Retain Squad
 
-- Worked on the Mobile Vikings prepaid registration project, helping the team adapt customer registration flows after Belgian regulation required prepaid SIM cards to be linked to verified identity.
+Mobile Vikings needed to adapt customer registration and retention flows while Belgian telecom regulation and backend platform changes reshaped core customer journeys.
+
+- Worked on prepaid registration flows after Belgian regulation required prepaid SIM cards to be linked to verified identity.
 - Built and maintained full-stack marketing campaign features for Mobile Vikings.
-- Helped analyze marketing backend changes for a full mobile virtual network operator (MVNO) migration, supporting Mobile Vikings' move from a direct telecom backend integration to a third-party-managed backend and a customer SIM-swap migration.
+- Helped analyze marketing backend changes for a full mobile virtual network operator (MVNO) migration and customer SIM-swap migration.
 
 ### [SoundTalks](https://www.soundtalks.com/en/)
 
@@ -121,11 +129,13 @@ I joined as the first employee, working in a small early-stage company where res
 
 Selected responsibilities and achievements:
 
+SoundTalks needed to turn acoustic livestock-health research into an operational product in a small early-stage company.
+
 - Led research and development work for the Pig Cough Monitor algorithm and supporting software.
 - Handled on-site installations, maintenance, data collection, and customer-facing technical follow-up.
 - Managed data storage and database work needed for algorithm development, validation, and product operation.
-- Developed software development practices around version control, build processes, and release management.
-- Represented the company at technical, academic, and commercial conferences, including direct interactions with potential partners and customers.
+- Developed software practices around version control, build processes, and release management.
+- Represented the company at technical, academic, and commercial conferences with partners and customers.
 
 ### [KU Leuven Medical Imaging Research Center](https://www.kuleuven.be/samenwerking/mirc)
 
@@ -218,6 +228,14 @@ Selected projects and responsibilities:
 - Science and physics, through books, podcasts, and general curiosity.
 - Music and culture, with a particular interest in electronic music.
 
+## Links
+
+- Location: [Tongeren-Borgloon, Belgium](geo:50.7865,5.4174)
+- GitHub: [mhemeryck](https://github.com/mhemeryck)
+- LinkedIn: [martijn-hemeryck](https://linkedin.com/in/martijn-hemeryck-67896245)
+- Blog: [Martyn's musings](https://mhemeryck.github.io/posts/)
+
 [^peppol]: [PEPPOL](https://peppol.org/) is the European e-invoicing network.
 [^open-banking]: Open banking in this context builds on the [Payment Services Directive](https://en.wikipedia.org/wiki/Payment_Services_Directive).
+[^coda]: [CODA](https://febelfin.be/en/themes/digitalization-innovation/regulations/a-coda-file-what-is-it-and-what-can-you-use-it-for), or geCOdeerd DAgafschrift, is a coded bank statement file type used in Belgium.
 [^stievie]: Stievie was a Belgian online streaming platform and predecessor to [VTM GO](https://www.vtmgo.be/).

--- a/content/cv.md
+++ b/content/cv.md
@@ -9,7 +9,7 @@ subtitle = "Martijn Hemeryck"
 - GitHub: [mhemeryck](https://github.com/mhemeryck)
 - LinkedIn: [martijn-hemeryck](https://linkedin.com/in/martijn-hemeryck-67896245)
 - Stack Overflow: [martyn](https://stackoverflow.com/users/1393391/martyn)
-- Blog: [Martyn's musings](/posts/)
+- Blog: [Martyn's musings](https://mhemeryck.github.io/posts/)
 
 ## Profile
 

--- a/content/cv.md
+++ b/content/cv.md
@@ -162,7 +162,7 @@ Selected projects and responsibilities:
 
 ### Thesis
 
-- M.Sc. thesis, with Hans Van Herck: ["Integrated Stereo Acoustic Echo Cancellation and Speech Coding for Tele-/videoconferencing Applications"](/cv/Hemeryck_Martijn_masterproef_2009-2010.pdf), KU Leuven, 2010.
+- M.Sc. thesis, with Hans Van Herck: ["Integrated Stereo Acoustic Echo Cancellation and Speech Coding for Tele-/videoconferencing Applications"](https://mhemeryck.github.io/cv/Hemeryck_Martijn_masterproef_2009-2010.pdf), KU Leuven, 2010.
 
 ### Publications
 
@@ -180,7 +180,7 @@ Selected projects and responsibilities:
 
 ## Selected Projects
 
-- [Personal home automation system](/tags/home-automation/): Designed, built, and maintain a whole-home automation setup integrating wired controls, UniPi hardware, Modbus, DALI, MQTT, Home Assistant, and custom Go/Python services.
+- Personal home automation system: Designed, built, and maintain a whole-home automation setup integrating wired controls, UniPi hardware, Modbus, DALI, MQTT, Home Assistant, and custom Go/Python services.
   - [nest](https://github.com/mhemeryck/nest): Go-based home automation codebase for consolidating personal automation services.
   - [modbridge](https://github.com/mhemeryck/modbridge): Go service for polling Modbus and Modbus TCP devices and publishing updates over MQTT.
   - [evok2mqtt](https://github.com/mhemeryck/evok2mqtt): Python bridge that listens to the UniPi EVOK API over websockets and publishes device events to MQTT.

--- a/content/cv.md
+++ b/content/cv.md
@@ -237,5 +237,5 @@ Selected projects and responsibilities:
 
 [^peppol]: [PEPPOL](https://peppol.org/) is the European e-invoicing network.
 [^open-banking]: Open banking in this context builds on the [Payment Services Directive](https://en.wikipedia.org/wiki/Payment_Services_Directive).
-[^coda]: [CODA](https://febelfin.be/en/themes/digitalization-innovation/regulations/a-coda-file-what-is-it-and-what-can-you-use-it-for), or geCOdeerd DAgafschrift, is a coded bank statement file type used in Belgium.
+[^coda]: [CODA](https://febelfin.be/en/themes/digitalization-innovation/regulations/a-coda-file-what-is-it-and-what-can-you-use-it-for), or "geCOdeerd DAgafschrift", is a coded bank statement file type used in Belgium.
 [^stievie]: Stievie was a Belgian online streaming platform and predecessor to [VTM GO](https://www.vtmgo.be/).

--- a/docs/projects/overhaul2026/cv.typ
+++ b/docs/projects/overhaul2026/cv.typ
@@ -89,7 +89,7 @@
 
     #v(0.25em)
     #text(size: 9pt, fill: muted)[
-      Senior Software Engineer | backend | cloud | systems | product platforms
+      dev | maker | engineer
     ]
   ],
   [#image("static/about/avatar-160.png", width: 24mm)],

--- a/docs/projects/overhaul2026/cv.typ
+++ b/docs/projects/overhaul2026/cv.typ
@@ -17,8 +17,8 @@
 )
 
 #set par(
-  leading: 0.64em,
-  spacing: 0.55em,
+  leading: 0.68em,
+  spacing: 0.8em,
 )
 
 #show link: it => {
@@ -27,50 +27,48 @@
 }
 
 #show list: it => {
-  set list(marker: "-", indent: 1.15em, body-indent: 0.45em)
+  set list(marker: "-", indent: 1.15em, body-indent: 0.45em, spacing: 0.35em)
   it
 }
 
 #show heading.where(level: 1): it => {
-  v(0.85em)
-  text(
-    font: "IBM Plex Mono",
-    size: 14pt,
-    weight: "bold",
-    fill: accent,
-    tracking: 0.5pt,
-  )[#it.body]
-  v(0.28em)
-  line(length: 100%, stroke: 0.6pt + accent-muted)
-  v(0.36em)
+  block(above: 1.15em, below: 0.6em)[
+    #text(
+      font: "IBM Plex Mono",
+      size: 14pt,
+      weight: "bold",
+      fill: accent,
+      tracking: 0.5pt,
+    )[#it.body]
+    #v(0.35em)
+    #line(length: 100%, stroke: 0.6pt + accent-muted)
+  ]
 }
 
-#show heading.where(level: 2): it => {
-  v(0.7em)
-  text(
+#show heading.where(level: 2): it => block(above: 0.95em, below: 0.45em)[
+  #text(
     font: "IBM Plex Mono",
     size: 9.5pt,
     weight: "bold",
     fill: accent,
     tracking: 0.35pt,
   )[#upper(it.body)]
-  v(0.22em)
-}
+]
 
-#show heading.where(level: 3): it => {
-  v(0.45em)
-  text(size: 10pt, weight: "bold")[#it.body]
-}
+#show heading.where(level: 3): it => block(above: 0.9em, below: 0.7em)[
+  #text(size: 10pt, weight: "bold")[#it.body]
+]
 
-#show heading.where(level: 4): it => {
-  v(0.36em)
-  text(
+#show heading.where(level: 4): it => block(above: 0.9em, below: 0.45em)[
+  #line(length: 100%, stroke: 0.35pt + rgb("#e1e8eb"))
+  #v(0.28em)
+  #text(
     font: "IBM Plex Mono",
-    size: 8.4pt,
+    size: 8.8pt,
     weight: "bold",
     fill: muted,
   )[#it.body]
-}
+]
 
 #show strong: it => text(weight: "bold")[#it.body]
 

--- a/docs/projects/overhaul2026/cv.typ
+++ b/docs/projects/overhaul2026/cv.typ
@@ -5,20 +5,20 @@
 
 #set page(
   paper: "a4",
-  margin: (x: 17mm, y: 14mm),
+  margin: (x: 18mm, y: 15mm),
   numbering: "1",
 )
 
 #set text(
   font: "IBM Plex Sans",
-  size: 9.6pt,
+  size: 10pt,
   fill: body-color,
   lang: "en",
 )
 
 #set par(
-  leading: 0.56em,
-  spacing: 0.45em,
+  leading: 0.64em,
+  spacing: 0.55em,
 )
 
 #show link: it => {
@@ -27,12 +27,12 @@
 }
 
 #show list: it => {
-  set list(marker: "-", indent: 1.05em, body-indent: 0.4em)
+  set list(marker: "-", indent: 1.15em, body-indent: 0.45em)
   it
 }
 
 #show heading.where(level: 1): it => {
-  v(0.7em)
+  v(0.85em)
   text(
     font: "IBM Plex Mono",
     size: 14pt,
@@ -40,13 +40,13 @@
     fill: accent,
     tracking: 0.5pt,
   )[#it.body]
-  v(0.22em)
-  line(length: 100%, stroke: 0.6pt + accent-muted)
   v(0.28em)
+  line(length: 100%, stroke: 0.6pt + accent-muted)
+  v(0.36em)
 }
 
 #show heading.where(level: 2): it => {
-  v(0.55em)
+  v(0.7em)
   text(
     font: "IBM Plex Mono",
     size: 9.5pt,
@@ -54,16 +54,16 @@
     fill: accent,
     tracking: 0.35pt,
   )[#upper(it.body)]
-  v(0.16em)
+  v(0.22em)
 }
 
 #show heading.where(level: 3): it => {
-  v(0.35em)
+  v(0.45em)
   text(size: 10pt, weight: "bold")[#it.body]
 }
 
 #show heading.where(level: 4): it => {
-  v(0.28em)
+  v(0.36em)
   text(
     font: "IBM Plex Mono",
     size: 8.4pt,

--- a/docs/projects/overhaul2026/cv.typ
+++ b/docs/projects/overhaul2026/cv.typ
@@ -1,0 +1,100 @@
+#let accent = rgb("#1f5f75")
+#let accent-muted = rgb("#bfd2d9")
+#let body-color = rgb("#202020")
+#let muted = rgb("#555555")
+
+#set page(
+  paper: "a4",
+  margin: (x: 17mm, y: 14mm),
+  numbering: "1",
+)
+
+#set text(
+  font: "IBM Plex Sans",
+  size: 9.6pt,
+  fill: body-color,
+  lang: "en",
+)
+
+#set par(
+  leading: 0.56em,
+  spacing: 0.45em,
+)
+
+#show link: it => {
+  set text(fill: accent)
+  it
+}
+
+#show list: it => {
+  set list(marker: "-", indent: 1.05em, body-indent: 0.4em)
+  it
+}
+
+#show heading.where(level: 1): it => {
+  v(0.7em)
+  text(
+    font: "IBM Plex Mono",
+    size: 14pt,
+    weight: "bold",
+    fill: accent,
+    tracking: 0.5pt,
+  )[#it.body]
+  v(0.22em)
+  line(length: 100%, stroke: 0.6pt + accent-muted)
+  v(0.28em)
+}
+
+#show heading.where(level: 2): it => {
+  v(0.55em)
+  text(
+    font: "IBM Plex Mono",
+    size: 9.5pt,
+    weight: "bold",
+    fill: accent,
+    tracking: 0.35pt,
+  )[#upper(it.body)]
+  v(0.16em)
+}
+
+#show heading.where(level: 3): it => {
+  v(0.35em)
+  text(size: 10pt, weight: "bold")[#it.body]
+}
+
+#show heading.where(level: 4): it => {
+  v(0.28em)
+  text(
+    font: "IBM Plex Mono",
+    size: 8.4pt,
+    weight: "bold",
+    fill: muted,
+  )[#it.body]
+}
+
+#show strong: it => text(weight: "bold")[#it.body]
+
+#grid(
+  columns: (1fr, 24mm),
+  gutter: 7mm,
+  align: (left, center),
+  [
+    #text(
+      font: "IBM Plex Mono",
+      size: 18pt,
+      weight: "bold",
+      fill: accent,
+      tracking: 0.8pt,
+    )[Martijn Hemeryck]
+
+    #v(0.25em)
+    #text(size: 9pt, fill: muted)[
+      Senior Software Engineer | backend | cloud | systems | product platforms
+    ]
+  ],
+  [#image("static/about/avatar-160.png", width: 24mm)],
+)
+
+#v(0.55em)
+
+$body$

--- a/docs/projects/overhaul2026/cv.typ
+++ b/docs/projects/overhaul2026/cv.typ
@@ -5,7 +5,7 @@
 
 #set page(
   paper: "a4",
-  margin: (x: 18mm, y: 15mm),
+  margin: (x: 17mm, y: 14mm),
   numbering: "1",
 )
 
@@ -18,7 +18,7 @@
 
 #set par(
   leading: 0.68em,
-  spacing: 0.8em,
+  spacing: 0.72em,
 )
 
 #show link: it => {

--- a/docs/projects/overhaul2026/plan.md
+++ b/docs/projects/overhaul2026/plan.md
@@ -14,7 +14,7 @@ The work is intentionally focused on getting a usable CV ready for job applicati
 
 - [x] [Phase 0: repository and tooling cleanup](plan#Phase 0: Repository And Tooling Cleanup)
 - [x] [Phase 1: about page and web CV](plan#Phase 1: About Page And Web CV)
-- [ ] [Phase 2: PDF CV](plan#Phase 2: PDF CV)
+- [x] [Phase 2: PDF CV](plan#Phase 2: PDF CV)
 - [ ] [Phase 3: application polish](plan#Phase 3: Application Polish)
 - [ ] [Phase 4: optional site overhaul](plan#Phase 4: Optional Site Overhaul)
 
@@ -115,18 +115,19 @@ Success criteria:
 
 Goal: generate a sendable PDF CV from the same source as the web CV.
 
-Status: in progress.
+Status: complete.
 
 The PDF is generated at build time from `content/cv.md` using Pandoc and Typst.
 The generated PDF is written to `public/cv/martijn-hemeryck-cv.pdf` and included in the GitHub Pages deployment artifact.
 Run `just cv-pdf` to regenerate it locally after building the site output directory.
+This generated PDF flow supersedes maintaining a separate LaTeX CV for the site.
 
 Tasks:
 
 - [x] choose the PDF generation approach
 - [x] generate a PDF CV from the CV source
-- [ ] verify the PDF layout is suitable for job applications
-- [ ] decide how the existing LaTeX CV should evolve or be retired
+- [x] verify the PDF layout is suitable for job applications
+- [x] decide how the existing LaTeX CV should evolve or be retired
 - [x] document the command for regenerating the PDF
 
 Success criteria:

--- a/docs/projects/overhaul2026/plan.md
+++ b/docs/projects/overhaul2026/plan.md
@@ -32,7 +32,7 @@ Focus on making existing seniority, ownership, and technical depth visible throu
 
 - [x] concise `about` page for the public profile
 - [x] complete web CV page used as the maintainable CV source
-- PDF CV generated from that source
+- [x] PDF CV generated from that source
 - [x] clear links to CV, LinkedIn, GitHub, and relevant writing
 - [x] minimal style improvements where they directly support readability and positioning
 
@@ -115,13 +115,19 @@ Success criteria:
 
 Goal: generate a sendable PDF CV from the same source as the web CV.
 
+Status: in progress.
+
+The PDF is generated at build time from `content/cv.md` using Pandoc and Typst.
+The generated PDF is written to `public/cv/martijn-hemeryck-cv.pdf` and included in the GitHub Pages deployment artifact.
+Run `just cv-pdf` to regenerate it locally after building the site output directory.
+
 Tasks:
 
-- [ ] choose the PDF generation approach
-- [ ] generate a PDF CV from the CV source
+- [x] choose the PDF generation approach
+- [x] generate a PDF CV from the CV source
 - [ ] verify the PDF layout is suitable for job applications
 - [ ] decide how the existing LaTeX CV should evolve or be retired
-- [ ] document the command for regenerating the PDF
+- [x] document the command for regenerating the PDF
 
 Success criteria:
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,15 @@
               go
               hugo
               just
+              liberation_ttf
+              nushell
+              pandoc
+              typst
             ];
+
+            shellHook = ''
+              export TYPST_FONT_PATHS=${pkgs.liberation_ttf}/share/fonts/truetype
+            '';
           };
         });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
               dprint
               go
               hugo
+              ibm-plex
               just
               liberation_ttf
               nushell
@@ -34,7 +35,7 @@
             ];
 
             shellHook = ''
-              export TYPST_FONT_PATHS=${pkgs.liberation_ttf}/share/fonts/truetype
+              export TYPST_FONT_PATHS=${pkgs.ibm-plex}/share/fonts:${pkgs.liberation_ttf}/share/fonts/truetype
             '';
           };
         });

--- a/justfile
+++ b/justfile
@@ -25,6 +25,7 @@ cv-pdf:
         | pandoc - \
             --from markdown+footnotes \
             --pdf-engine typst \
+            --template docs/projects/overhaul2026/cv.typ \
             --metadata title=CV \
             --metadata 'author=Martijn Hemeryck' \
             --metadata lang=en \

--- a/justfile
+++ b/justfile
@@ -1,3 +1,5 @@
+set shell := ["nu", "-c"]
+
 default:
     just --list
 
@@ -6,10 +8,25 @@ serve:
 
 build:
     hugo --minify
+    just cv-pdf
 
 check:
     dprint check
     hugo --minify
+    just cv-pdf
 
 format:
     dprint fmt
+
+cv-pdf:
+    mkdir public/cv
+    open --raw content/cv.md \
+        | str replace --regex '(?s)^\+\+\+\r?\n.*?\r?\n\+\+\+\r?\n*' '' \
+        | pandoc - \
+            --from markdown+footnotes \
+            --pdf-engine typst \
+            --metadata title=CV \
+            --metadata 'author=Martijn Hemeryck' \
+            --metadata lang=en \
+            --metadata 'mainfont=Liberation Serif' \
+            --output public/cv/martijn-hemeryck-cv.pdf


### PR DESCRIPTION
Generate CV PDF during site build

Build the CV PDF from the shared Markdown source during the site build so
web and PDF outputs stay aligned without committing generated artifacts.

This also adds a custom Typst template for the PDF, wires the deploy and
PR build workflows through the Nix development shell, and marks Phase 2 of
the CV overhaul complete.
