### PR TITLE
Adopt re-terminal theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .wordlist.dic
 public/
+resources/_gen/

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 I like to use this repo to dump some random notes-to-self, which also happen to be shared with the rest of the world.
 
-Deployed using [github pages], theme stolen from [hugo beautiful jekyll], which in turns was stolen from [beautiful jekyll].
+Deployed using [github pages] with the [re-terminal] Hugo theme.
 
 [github pages]: https://pages.github.com/
-[hugo beautiful jekyll]: https://github.com/halogenica/beautifulhugo
-[beautiful jekyll]: https://beautifuljekyll.com/
+[re-terminal]: https://github.com/mirus-ua/hugo-theme-re-terminal
 
 ## Local development
 

--- a/docs/projects/overhaul2026/plan.md
+++ b/docs/projects/overhaul2026/plan.md
@@ -16,7 +16,7 @@ The work is intentionally focused on getting a usable CV ready for job applicati
 - [x] [Phase 1: about page and web CV](plan#Phase 1: About Page And Web CV)
 - [x] [Phase 2: PDF CV](plan#Phase 2: PDF CV)
 - [ ] [Phase 3: application polish](plan#Phase 3: Application Polish)
-- [ ] [Phase 4: optional site overhaul](plan#Phase 4: Optional Site Overhaul)
+- [ ] [Phase 4: re-terminal site rebrand](plan#Phase 4: Re-Terminal Site Rebrand)
 
 ## Near-Term Scope
 
@@ -154,12 +154,20 @@ Success criteria:
 - the CV communicates systems thinking, ownership, and delivery
 - the application materials are ready to share
 
-## Phase 4: Optional Site Overhaul
+## Phase 4: Re-Terminal Site Rebrand
 
-Goal: improve the surrounding site only if the current setup becomes limiting.
+Goal: rebrand the surrounding site with the re-terminal Hugo theme while preserving the CV and writing work already completed.
+
+The site should keep the existing Hugo setup and URLs unless there is a concrete reason to change them.
+The initial migration should stay small and focus on theme adoption, navigation, readability, and build stability.
 
 Tasks:
 
+- [x] migrate the Hugo theme from Beautiful Hugo to re-terminal
+- [x] configure the site title, subtitle, logo text, menu, and theme color for the new brand
+- [x] preserve existing URLs for about, CV, posts, and the generated PDF CV
+- [x] verify the web CV and blog posts render with the new theme
+- [x] verify the production build and PDF generation still work
 - [ ] add project pages or case studies only if they support applications
 - [ ] decide whether to stay on Hugo or migrate to Zola only if there is a concrete reason
 - [ ] replace the current theme-driven style with custom templates and CSS only if needed

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/mhemeryck/mhemeryck.github.io
 
 go 1.26.3
 
-require github.com/halogenica/beautifulhugo v0.0.0-20260601040702-28288164b6b5 // indirect
+require (
+	github.com/mirus-ua/hugo-theme-re-terminal v1.2.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/halogenica/beautifulhugo v0.0.0-20260601040702-28288164b6b5 h1:fmuD0J3MF2nVzRiCtrGuBFUeHRWlQy8773ZRwwuRmt8=
-github.com/halogenica/beautifulhugo v0.0.0-20260601040702-28288164b6b5/go.mod h1:4dwHt6njigk+fr9W3Bg+OflL4LKzkjbXAULXvr3mYLs=
+github.com/mirus-ua/hugo-theme-re-terminal v1.2.1 h1:vikctH4TP2pvNu/2WDbM+LrX1ugP5fi6iu2xddjJPck=
+github.com/mirus-ua/hugo-theme-re-terminal v1.2.1/go.mod h1:lbM8zlTK8TYbfKyu4m3v/wvZZFALjfxm4JI3OvWLn30=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,26 +1,67 @@
 baseURL = "https://mhemeryck.xyz/"
 locale = "en-us"
-title = "Martijn's musings"
-theme = "github.com/halogenica/beautifulhugo"
+title = "mhemeryck"
+pagination.pagerSize = 10
 
 [params]
+contentTypeName = "posts"
 favicon = "favicon.ico"
+themeColor = "orange"
+showMenuItems = 5
+showLanguageSelector = false
+fullWidthTheme = false
+centerTheme = false
+autoCover = true
+showLastUpdated = false
 readingTime = true
-wordCount = true
-socialShare = true
 
-[params.author]
-name = "Martijn Hemeryck"
-website = "https://mhemeryck.xyz"
-github = "mhemeryck"
-linkedin = "martijn-hemeryck-67896245"
-twitter = "MartijnHemeryck"
-reddit = "mhemeryck"
-strava = "26120201"
+[params.twitter]
+creator = "MartijnHemeryck"
+site = "MartijnHemeryck"
+
+[languages]
+[languages.en.params]
+languageName = "English"
+title = "mhemeryck"
+subtitle = "Systems, software, and notes from the edge cases"
+owner = "Martijn Hemeryck"
+keywords = "software engineering, backend, cloud, infrastructure, home automation"
+copyright = "Martijn Hemeryck"
+menuMore = "More"
+readMore = "Read more"
+readOtherPosts = "Read other posts"
+newerPosts = "Newer posts"
+olderPosts = "Older posts"
+missingContentMessage = "Page not found"
+missingBackButtonLabel = "Back to home"
+minuteReadingTime = "min read"
+words = "words"
+
+[languages.en.params.logo]
+logoText = "mhemeryck"
+logoHomeLink = "/"
+
+[languages.en.menu]
+[[languages.en.menu.main]]
+identifier = "about"
+name = "About"
+url = "/about/"
+[[languages.en.menu.main]]
+identifier = "cv"
+name = "CV"
+url = "/cv/"
+[[languages.en.menu.main]]
+identifier = "posts"
+name = "Writing"
+url = "/posts/"
+[[languages.en.menu.main]]
+identifier = "github"
+name = "GitHub"
+url = "https://github.com/mhemeryck"
+[[languages.en.menu.main]]
+identifier = "linkedin"
+name = "LinkedIn"
+url = "https://linkedin.com/in/martijn-hemeryck-67896245"
 
 [[module.imports]]
-path = "github.com/halogenica/beautifulhugo"
-
-[[menu.main]]
-name = "About me"
-url = "/about/"
+path = "github.com/mirus-ua/hugo-theme-re-terminal"

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,35 @@
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = .Site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+  {{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+  {{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := .Site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+  {{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>
+    {{ with .Site.Language.Locale }}<language>{{ . }}</language>{{ end }}
+    {{ with .Site.Copyright }}<copyright>{{ . }}</copyright>{{ end }}
+    {{ if not .Date.IsZero }}<lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}{{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}{{ end }}
+    {{ range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      {{ if not .Date.IsZero }}<pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | html }}</description>
+      <content:encoded>{{ .Content | html }}</content:encoded>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,0 +1,94 @@
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description }}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+<meta name="keywords" content="{{ with .Params.Keywords }}{{ delimit . ", " }}{{ else }}{{ $.Site.Params.Keywords }}{{ end }}" />
+{{ if .Params.noindex }}
+  {{ if or (eq (.Param "noindex") true) (eq (.Param "noindex") "true") }}
+    <meta name="robots" content="noindex" />
+  {{ end }}
+{{ else }}
+  <meta name="robots" content="noodp" />
+{{ end }}
+<link rel="canonical" href="{{ .Permalink }}" />
+
+{{ template "_internal/google_analytics.html" . }}
+
+{{ $defaultStyles := resources.Get "css/style.scss" }}
+<!-- Local Theme Variables -->
+{{ if and (isset .Params "color") (not (eq .Params.color "")) }}
+  {{ $localColorCss := resources.Get (printf "css/color/%s.scss" .Params.color) }}
+  {{ $localCss := slice $localColorCss $defaultStyles | resources.Concat (printf "css/%s-local.scss" .Params.color) }}
+  {{ $localColorStyles := $localCss | css.Sass }}
+  <link rel="stylesheet" href="{{ $localColorStyles.Permalink }}">
+{{ else }}
+  <!-- Theme Variables -->
+  {{ $colorCss := resources.Get (printf "css/color/%s.scss" ($.Site.Params.ThemeColor | default "orange")) }}
+  {{ $css := slice $colorCss $defaultStyles | resources.Concat "css/base.scss" }}
+  {{ $options := dict "targetPath" "styles.css" "outputStyle" "compressed" "enableSourceMap" true "precision" 6 "includePaths" (slice "node_modules") }}
+  {{ $styles := $css | css.Sass $options }}
+  <link rel="stylesheet" href="{{ $styles.Permalink }}">
+{{ end }}
+
+<!-- Custom CSS to override theme properties (/static/style.css) -->
+{{ if (fileExists "static/style.css") -}}
+  <link rel="stylesheet" href="{{ "style.css" | absURL }}">
+{{- end }}
+
+<!-- Icons -->
+{{ if isset $.Site.Params "favicon" }}
+  <link rel="shortcut icon" href="{{ $.Site.Params.favicon | absURL }}">
+{{ else }}
+  <link rel="shortcut icon" href="{{ printf "img/theme-colors/%s.png" (or .Params.color $.Site.Params.ThemeColor | default "orange") | absURL }}">
+  <link rel="apple-touch-icon" href="{{ printf "img/theme-colors/%s.png" (or .Params.color $.Site.Params.ThemeColor | default "orange") | absURL }}">
+{{ end }}
+
+<!-- Twitter Card -->
+<meta name="twitter:card" content="summary" />
+{{ if isset $.Site.Params "twitter" }}
+  {{ if isset $.Site.Params.Twitter "site" }}
+    <meta name="twitter:site" content="{{ $.Site.Params.Twitter.site }}" />
+  {{ end }}
+  <meta name="twitter:creator" content="{{ if .IsHome }}{{ $.Site.Params.Twitter.creator }}{{ else if isset .Params "authortwitter" }}{{ .Params.authorTwitter }}{{ else }}{{ .Params.Author }}{{ end }}" />
+{{ end }}
+
+<!-- OG data -->
+<meta property="og:locale" content="{{ $.Site.Language.Lang }}" />
+<meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
+<meta property="og:title" content="{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }}{{ end }}">
+<meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description }}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+<meta property="og:url" content="{{ .Permalink }}" />
+<meta property="og:site_name" content="{{ $.Site.Title }}" />
+{{ if isset .Params "cover" }}
+  {{ $pageCover := .Param "cover" }}
+  {{ with .Resources.GetMatch (.Param "cover") }}
+    {{ $pageCover = .RelPermalink }}
+  {{ end }}
+  <meta property="og:image" content="{{ $pageCover | absURL }}">
+{{ else }}
+  {{ if isset $.Site.Params "favicon" }}
+    <meta property="og:image" content="{{ $.Site.Params.favicon | absURL }}">
+  {{ else }}
+    <meta property="og:image" content="{{ printf "img/favicon/%s.png" $.Site.Params.ThemeColor | absURL }}">
+  {{ end }}
+{{ end }}
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content="627">
+{{ range .Params.categories }}
+  <meta property="article:section" content="{{ . }}" />
+{{ end }}
+{{ if isset .Params "date" }}
+  <meta property="article:published_time" content="{{ time .Date }}" />
+{{ end }}
+
+<!-- RSS -->
+{{ with .OutputFormats.Get "RSS" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+{{ end }}
+
+<!-- JSON Feed -->
+{{ with .OutputFormats.Get "json" }}
+  <link href="{{ .RelPermalink }}" rel="alternate" type="application/json" title="{{ $.Site.Title }}" />
+{{ end }}
+
+<!-- Extended head section-->
+{{ partial "extended_head.html" . }}


### PR DESCRIPTION
Adopt re-terminal theme

Use the re-terminal theme as the basis for the site rebrand while
preserving the existing CV and writing URLs.

Keep the migration small by using Hugo module dependencies and local
compatibility overrides for current Hugo APIs instead of vendoring the
full theme.
