### PR TITLE
Use configured Pages base URL

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -47,8 +47,7 @@ jobs:
           HUGO_ENV: production
         run: |
           nix develop --command hugo \
-            --minify \
-            --baseURL "${{ steps.pages.outputs.base_url }}/"
+            --minify
       - name: Build CV PDF
         run: nix develop --command just cv-pdf
       - name: Upload artifact


### PR DESCRIPTION
Use configured Pages base URL

Avoid generating HTTP asset URLs during deployment by relying on the
checked-in HTTPS Hugo baseURL instead of the Pages action output.

The deployed re-terminal theme emits absolute stylesheet URLs, so an
HTTP base URL causes browsers to block the CSS as mixed content on the
HTTPS site.
