### PR TITLE
Refresh CV PDF styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.hugo_build.lock
 .wordlist.dic
 public/
 resources/_gen/

--- a/content/cv.md
+++ b/content/cv.md
@@ -230,7 +230,7 @@ Selected projects and responsibilities:
 
 ## Links
 
-- Location: [Tongeren-Borgloon, Belgium](geo:50.7865,5.4174)
+- Location: Flanders, Belgium
 - GitHub: [mhemeryck](https://github.com/mhemeryck)
 - LinkedIn: [martijn-hemeryck](https://linkedin.com/in/martijn-hemeryck-67896245)
 - Blog: [Martyn's musings](https://mhemeryck.github.io/posts/)

--- a/flake.nix
+++ b/flake.nix
@@ -32,10 +32,11 @@
               nushell
               pandoc
               typst
+              nerd-fonts.fira-code
             ];
 
             shellHook = ''
-              export TYPST_FONT_PATHS=${pkgs.ibm-plex}/share/fonts:${pkgs.liberation_ttf}/share/fonts/truetype
+              export TYPST_FONT_PATHS=${pkgs.nerd-fonts.fira-code}/share/fonts:${pkgs.ibm-plex}/share/fonts:${pkgs.liberation_ttf}/share/fonts/truetype
             '';
           };
         });

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/mhemeryck/mhemeryck.github.io
 
 go 1.26.3
 
-require (
-	github.com/mirus-ua/hugo-theme-re-terminal v1.2.1 // indirect
-)
+require github.com/mirus-ua/hugo-theme-re-terminal v1.2.1 // indirect

--- a/layouts/cv.typ
+++ b/layouts/cv.typ
@@ -1,7 +1,7 @@
-#let accent = rgb("#1f5f75")
-#let accent-muted = rgb("#bfd2d9")
-#let body-color = rgb("#202020")
-#let muted = rgb("#555555")
+#let accent = rgb("#ffa86a")
+#let accent-muted = rgb("#ffd7bd")
+#let body-color = rgb("#222129")
+#let muted = rgb("#5f5c65")
 
 #set page(
   paper: "a4",
@@ -10,8 +10,8 @@
 )
 
 #set text(
-  font: "IBM Plex Sans",
-  size: 10pt,
+  font: "FiraCode Nerd Font",
+  size: 9.4pt,
   fill: body-color,
   lang: "en",
 )
@@ -34,7 +34,7 @@
 #show heading.where(level: 1): it => {
   block(above: 1.15em, below: 0.6em)[
     #text(
-      font: "IBM Plex Mono",
+      font: "FiraCode Nerd Font",
       size: 14pt,
       weight: "bold",
       fill: accent,
@@ -47,7 +47,7 @@
 
 #show heading.where(level: 2): it => block(above: 0.95em, below: 0.45em)[
   #text(
-    font: "IBM Plex Mono",
+    font: "FiraCode Nerd Font",
     size: 9.5pt,
     weight: "bold",
     fill: accent,
@@ -60,10 +60,10 @@
 ]
 
 #show heading.where(level: 4): it => block(above: 0.9em, below: 0.45em)[
-  #line(length: 100%, stroke: 0.35pt + rgb("#e1e8eb"))
+  #line(length: 100%, stroke: 0.35pt + rgb("#f0e2d8"))
   #v(0.28em)
   #text(
-    font: "IBM Plex Mono",
+    font: "FiraCode Nerd Font",
     size: 8.8pt,
     weight: "bold",
     fill: muted,
@@ -78,7 +78,7 @@
   align: (left, center),
   [
     #text(
-      font: "IBM Plex Mono",
+      font: "FiraCode Nerd Font",
       size: 18pt,
       weight: "bold",
       fill: accent,

--- a/layouts/cv.typ
+++ b/layouts/cv.typ
@@ -10,8 +10,8 @@
 )
 
 #set text(
-  font: "FiraCode Nerd Font",
-  size: 9.4pt,
+  font: "IBM Plex Sans",
+  size: 10pt,
   fill: body-color,
   lang: "en",
 )


### PR DESCRIPTION
Refresh CV PDF styling

Align the generated PDF more closely with the site theme by using the
site accent color and Fira Code for the CV header and headings.

Keep IBM Plex Sans for body text so the PDF remains readable as an
application document, and add the Fira Code font package to the Nix
development shell so PDF generation remains reproducible.
